### PR TITLE
polish: add subtitle and TOC to local-llm post

### DIFF
--- a/content/article/local-llm-seven-wrong-answers.md
+++ b/content/article/local-llm-seven-wrong-answers.md
@@ -1,8 +1,13 @@
 ---
 date: 2026-04-25T00:00:00-04:00
-description: "Seven attempts, seven different wrong answers — a tour of the local LLM stack through its failures."
+description: "Seven attempts, seven different wrong answers — lessons from setting up a local LLM."
 tags: ["llm", "local-llm", "ollama", "ai"]
 title: "I Asked My Local LLM to Add 23 Numbers. I Got Seven Different Wrong Answers."
+toc: true
+---
+
+*Seven attempts, seven different wrong answers — lessons from setting up a local LLM.*
+
 ---
 
 It's tax season, which means I've been staring at a notes file full of stock sales — 23 transactions across the year that I needed to total up. The kind of data I'd rather not paste into a chat window I don't control.

--- a/layouts/partials/menu-contextual.html
+++ b/layouts/partials/menu-contextual.html
@@ -1,0 +1,33 @@
+{{/*
+  Use Hugo's native Table of contents feature. You must set `toc: true` in your parameters for this to show.
+  https://gohugo.io/content-management/toc/
+*/}}
+
+{{- if .Params.toc -}}
+  <div class="bg-light-gray pa3 nested-list-reset nested-copy-line-height nested-links">
+    <p class="f5 b mb3">{{ i18n "whatsInThis" }} {{ humanize .Type }}</p>
+      {{ .TableOfContents }}
+  </div>
+{{- end -}}
+
+{{/*
+  Use Hugo's native related content feature to pull in content that may have similar parameters, like tags. etc.
+  https://gohugo.io/content-management/related/
+*/}}
+
+{{ $related := .Site.RegularPages.Related . | first 15 }}
+
+{{ with $related }}
+  <div class="bg-light-gray pa3 nested-list-reset nested-copy-line-height nested-links">
+    <p class="f5 b mb3">{{ i18n "related" }}</p>
+    <ul class="pa0 list">
+	   {{ range . }}
+	     <li  class="mb2">
+          <a href="{{ .RelPermalink }}">
+            {{- .Title -}}
+          </a>
+        </li>
+	    {{ end }}
+    </ul>
+</div>
+{{ end }}

--- a/layouts/partials/menu-contextual.html
+++ b/layouts/partials/menu-contextual.html
@@ -5,7 +5,7 @@
 
 {{- if .Params.toc -}}
   <div class="bg-light-gray pa3 nested-list-reset nested-copy-line-height nested-links">
-    <p class="f5 b mb3">{{ i18n "whatsInThis" }} {{ humanize .Type }}</p>
+    <p class="f5 b mb3">{{ i18n "whatsInThis" (dict "Type" (humanize .Type)) }}</p>
       {{ .TableOfContents }}
   </div>
 {{- end -}}


### PR DESCRIPTION
## Summary
- Enable `toc: true` so the right sidebar shows a table of contents (the post has 9 H2s and no related-tag matches, so the sidebar was empty before)
- Add an italic subtitle + horizontal rule above the body, matching the postgres-gateway-drug header pattern
- Update front-matter description to drop "tour" framing per author

## Test plan
- [x] `hugo --quiet` builds clean
- [ ] Cloudflare Pages preview renders title + sidebar + body without regressions
- [ ] TOC anchors land on correct sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)